### PR TITLE
♻️ refactor: 更新课表改为直接拉取，移除 Basic 广播下发

### DIFF
--- a/js/renderer.js
+++ b/js/renderer.js
@@ -1030,14 +1030,6 @@ ipcRenderer.on('updateWeather', () => {
     ipcRenderer.send('getWeather', false)
 })
 
-ipcRenderer.on('broadcastSyncConfig', () => {
-    // Serverless 模式下直接拉取课表，无需广播
-    if (globalThis.websocketDisabled) {
-        ipcRenderer.send('getScheduleFromCloud');
-        return;
-    }
-    ipcRenderer.send('RequestSyncConfig', false)
-})
 
 
 // WebSocket连接状态处理

--- a/main.js
+++ b/main.js
@@ -653,9 +653,13 @@ function getScheduleFromCloud() {
 
         if (statusCode < 200 || statusCode >= 300) {
             console.error('getScheduleFromCloud request failed with status:', statusCode);
-            // 尝试重连
-            if (statusCode !== 304) {
-                setTimeout(getScheduleFromCloud, 5000)
+            // 仅最新请求允许安排重试；被替代的请求不得发起后续请求（调度时与执行时双重校验）
+            if (mySeq === scheduleFetchSeq) {
+                setTimeout(() => {
+                    if (mySeq === scheduleFetchSeq) {
+                        getScheduleFromCloud()
+                    }
+                }, 5000)
             }
             return;
         }
@@ -750,8 +754,14 @@ function getScheduleFromCloud() {
     request.on('error', (err) => {
         console.error('getScheduleFromCloud request error:', err)
         // 不显示错误弹窗，仅记录错误
-        // 稍后重试
-        setTimeout(getScheduleFromCloud, 5000)
+        // 仅最新请求允许重试，且回调执行前再次校验，被替代的请求不得发起后续请求
+        if (mySeq === scheduleFetchSeq) {
+            setTimeout(() => {
+                if (mySeq === scheduleFetchSeq) {
+                    getScheduleFromCloud()
+                }
+            }, 5000)
+        }
     })
     request.end()
 }

--- a/main.js
+++ b/main.js
@@ -622,11 +622,18 @@ async function getScheduleFromCloudWithRetry(maxRetries = 10) {
     return false
 }
 
+// 课表拉取并发控制：记录最新一次请求的序号。托盘连点 / WS 推送 / 自动刷新 / 失败重试
+// 可能并发触发，响应到达时只允许最新请求生效，过期响应直接丢弃，防止旧配置覆盖新配置
+let scheduleFetchSeq = 0
+
 function getScheduleFromCloud() {
     const { agreement } = getProtocols()
     // 添加 version 查询参数
     const url = `${agreement}://${getServer()}/${classId}?version=${currentVersion}`
     console.log('Requesting schedule from cloud:', url);
+
+    // 本次请求的序号，响应到达时校验是否仍为最新请求
+    const mySeq = ++scheduleFetchSeq
 
     // noinspection JSCheckFunctionSignatures
     const request = astraRequest({
@@ -659,6 +666,20 @@ function getScheduleFromCloud() {
         response.on('end', () => {
             try {
                 const scheduleConfigSync = JSON.parse(raw)
+
+                // 过期响应保护：已有更新的请求在途，或返回版本低于本地已应用版本，
+                // 直接丢弃，不得更新 currentVersion / lastScheduleConfig / 倒数日缓存 / newConfig 推送
+                if (mySeq !== scheduleFetchSeq) {
+                    console.warn('[Schedule] Discard stale response: superseded by a newer request')
+                    return
+                }
+                if (scheduleConfigSync.version !== undefined) {
+                    const respVersion = Number.parseInt(scheduleConfigSync.version)
+                    if (!Number.isNaN(respVersion) && respVersion < currentVersion) {
+                        console.warn(`[Schedule] Discard stale response: version ${respVersion} < ${currentVersion}`)
+                        return
+                    }
+                }
                 console.log('Received schedule config from cloud:', scheduleConfigSync)
 
                 // 检查返回的 JSON 中是否含有 version 键

--- a/main.js
+++ b/main.js
@@ -916,12 +916,8 @@ ipcMain.on('getWeekIndex', (e, arg) => {
             icon: asset('image', 'toggle.png'),
             label: '更新课表',
             click: () => {
-                // Serverless 模式下直接拉取课表，无需广播
-                if (websocketDisabled) {
-                    getScheduleFromCloud();
-                    return;
-                }
-                win.webContents.send('broadcastSyncConfig')
+                // 与 Serverless 模式一致：直接拉取课表（服务端已废弃外部广播入口）
+                getScheduleFromCloud();
             }
         },
         {
@@ -1204,50 +1200,6 @@ ipcMain.on('getWeather', () => {
     if (weatherRequestInFlight || weatherRetryTimer) return
     weatherRetryCount = 0
     requestWeatherWithRetry()
-})
-
-ipcMain.on('RequestSyncConfig', () => {
-    prompt({
-        title: '云端密码',
-        label: '请输入密码：',
-        value: "",
-        inputAttrs: { type: 'password' },
-        type: 'input',
-        height: 180,
-        width: 400,
-        icon: asset('image', 'toggle.png'),
-    }).then((r) => {
-        if (r === null) return;
-        const { agreement } = getProtocols()
-        // noinspection JSCheckFunctionSignatures
-        const request = astraRequest({
-            method: 'POST',
-            url: `${agreement}://${getServer()}/api/broadcast/${classId}`,
-            headers: {
-                "Authorization": 'Basic ' + Buffer.from('ElectronClassSchedule:' + String(r)).toString('base64'),
-            }
-        })
-        try {
-            request.on('response', (response) => {
-                response.on('data', () => {})
-                response.on('end', () => {
-                    const { dialog } = require('electron');
-                    if (response.statusCode === 200) {
-                        dialog.showMessageBox(
-                            { type: 'info', title: '提示', message: '已下发成功', buttons: ['已阅'] }).then(doNothing)
-                    } else if (response.statusCode === 401) {
-                        dialog.showMessageBox({ type: 'error', title: '错误', message: '服务端返回 401，可能密码错误', buttons: ['已阅'] }).then(doNothing)
-                    } else {
-                        dialog.showMessageBox({ type: 'error', title: '错误', message: `服务端返回 ${response.statusCode}` , buttons: ['已阅'] }).then(doNothing)
-                    }
-                })
-            })
-        } catch (e) {
-            console.log(e)
-        }
-        request.on('error', (err) => console.error('Broadcast request error:', err))
-        request.end()
-    })
 })
 
 // 处理来自渲染进程的tray状态更新请求

--- a/main/preload.js
+++ b/main/preload.js
@@ -15,7 +15,6 @@ const SEND_CHANNELS = new Set([
     'debugCalibrationData',
     'fromCloud',
     'setClass',
-    'RequestSyncConfig',
     'update-tray-status',
 ]);
 
@@ -48,7 +47,6 @@ const ON_CHANNELS = new Set([
     'setWeather',
     'debugInputChanged',
     'updateWeather',
-    'broadcastSyncConfig',
     'ws-status',
     'update-tray-status',
 ]);


### PR DESCRIPTION
## 变更内容

按后端契约审查结论：后端（usr-backend）已废弃外部广播入口（AdminOrToken 只认 JWT，desktop 发送的 Basic 认证始终 401），本 PR 把客户端的“下发”行为改为“拉取”，与 Serverless 模式保持一致。

### 改动

- 托盘“更新课表”不再走密码提示 + `POST /api/broadcast`（Basic）下发，改为直接调用 `getScheduleFromCloud()` 拉取课表（该函数会更新主窗口配置并刷新倒数日窗口）。
- 移除 `ipcMain.on('RequestSyncConfig')` 处理器（云端密码提示 + Basic 广播请求，该路径对当前后端必然 401）。
- 移除 renderer.js 的 `broadcastSyncConfig` 监听（唯一触发 RequestSyncConfig 的入口）。

### 影响

- 有 WS 模式与 Serverless 模式行为统一：手动“更新课表”均走拉取。
- WS 推送能力不受影响：服务端内部广播（如 PutSettings 的 SyncConfig 消息）仍会触发本机自动刷新。



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 功能调整

* 托盘菜单中的“更新课表”现在会直接从云端获取最新课表。
* 简化课表更新操作，不再根据连接状态执行不同的同步方式。
* 移除了同步配置请求、密码输入及相关结果提示流程。

## Bug 修复

* 优化课表更新结果校验，避免较旧或过期的请求响应覆盖当前数据。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
